### PR TITLE
Clean old network interfaces so the new one will become eth0

### DIFF
--- a/cloudstack-centos-6/scripts/cleanup.sh
+++ b/cloudstack-centos-6/scripts/cleanup.sh
@@ -2,4 +2,8 @@
 
 set -x
 
+# Clean old network interfaces so the new one will become eth0
+rm /etc/udev/rules.d/70-persistent-net.rules
+
 fstrim -v /
+


### PR DESCRIPTION
```
    qemu: Complete!
==> qemu: Provisioning with shell script: scripts/cleanup.sh
    qemu: + rm /etc/udev/rules.d/70-persistent-net.rules
    qemu: + fstrim -v /
    qemu: /: 6672400384 bytes were trimmed
==> qemu: Uploading files/cloud.cfg => /etc/cloud/cloud.cfg
==> qemu: Uploading files/99_cloudstack.cfg => /etc/cloud/cloud.cfg.d/99_cloudstack.cfg
==> qemu: Gracefully halting virtual machine...
==> qemu: Converting hard drive...
Build 'qemu' finished.```