### PR TITLE
Set a failback root password

### DIFF
--- a/cloudstack-centos-6/files/cloud.cfg
+++ b/cloudstack-centos-6/files/cloud.cfg
@@ -3,6 +3,10 @@ users:
 
 disable_root: 0
 ssh_pwauth:   1
+chpasswd:
+  list: |
+    root:password
+  expire: False
 
 locale_configfile: /etc/sysconfig/i18n
 mount_default_fields: [~, ~, 'auto', 'defaults,nofail', '0', '2']

--- a/cosmic-centos-7/files/cloud.cfg
+++ b/cosmic-centos-7/files/cloud.cfg
@@ -3,6 +3,10 @@ users:
 
 disable_root: 0
 ssh_pwauth:   1
+chpasswd:
+  list: |
+    root:password
+  expire: False
 
 locale_configfile: /etc/sysconfig/i18n
 mount_default_fields: [~, ~, 'auto', 'defaults,nofail', '0', '2']


### PR DESCRIPTION
This is a fallback method. If a new password is received via metadata server, this is set.